### PR TITLE
Convert Mirror.startGame to Java code

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ public class ExampleBot {
 
             @Override
             public void onFrame() {
+                // this object is ONLY valid while Mirror.startGame is running
+                // (which is fine 99% of the time, it just means you should only
+                // use it within code that is invoked from these listener methods)
                 Game game = mirror.getGame();
                 Player self = game.self();
 
@@ -47,12 +50,16 @@ public class ExampleBot {
             }
         });
 
-        // blocks indefinitely
-        mirror.startGame();
+        // if you pass true, blocks indefinitely and keeps Broodwar instance
+        // connection to keep playing subsequent matches.
+        // if you pass false, startGame will return after a single match and
+        // disconnects from the Broodwar instance. you can call startGame as
+        // many times as you wish in this case.
+        mirror.startGame(true);
     }
 
     public static void main(String... args) {
-        new TestBot().run();
+        new ExampleBot().run();
     }
 }
 ```

--- a/bwmirror/pom.xml
+++ b/bwmirror/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.github.gered</groupId>
 	<artifactId>bwmirror</artifactId>
-	<version>2.6</version>
+	<version>2.7</version>
 	<packaging>jar</packaging>
 
 	<name>BWMirror</name>

--- a/bwmirror/src/test/java/bwmirror/TestBot.java
+++ b/bwmirror/src/test/java/bwmirror/TestBot.java
@@ -138,7 +138,7 @@ public class TestBot {
             }
         });
           */
-        mirror.startGame();
+        mirror.startGame(false);
         System.out.println("It's over");
     }
 

--- a/generator/src/main/java/bwmirror/generator/c/Bind.java
+++ b/generator/src/main/java/bwmirror/generator/c/Bind.java
@@ -30,162 +30,149 @@ public class Bind {
         this.context = context;
     }
 
-    private void implementConnectionRoutine() {
-        out.println("\t\t\t\tprintln(\"Waiting...\");\n" +
-                "while ( !Broodwar->isInGame() )\n" +
-                "    {\n" +
-                "      BWAPI::BWAPIClient.update();\n" +
-                "      if (!BWAPI::BWAPIClient.isConnected())\n" +
-                "      {\n" +
-                "        println(\"Reconnecting...\");\n" +
-                "        reconnect();\n" +
-                "      }\n" +
-                "    }");
-    }
-
-
-    private void implementGameStart() {
-        out.println("println(\"Connecting to Broodwar...\");\n" +
-                "\t\treconnect();\n" +
-                "\t\tprintln(\"Connection successful, starting match...\");\n" +
-                "\n" +
-                "\t\tcls = env->GetObjectClass(obj);\n" +
-                "\t\tjclass gamecls = env->FindClass(\"L" + context.getPackageName() + "/Game;\");\n" +
-                "\t\tjclass unitCls = env->FindClass(\"L" + context.getPackageName() + "/Unit;\");\n" +
-                "\t\tjclass playerCls = env->FindClass(\"L" + context.getPackageName() + "/Player;\");\n" +
-                "\t\tjclass posCls = env->FindClass(\"L" + context.getPackageName() + "/Position;\");\n" +
-                "\t\tjobject moduleObj = env->GetObjectField(obj, env->GetFieldID(cls, \"module\", \"L" + context.getPackageName() + "/AIModule;\"));\n" +
-                "\t\tjclass moduleCls = env->GetObjectClass(moduleObj);\n" +
-                "\t\tenv->SetObjectField(obj, env->GetFieldID(cls, \"game\", \"L" + context.getPackageName() + "/Game;\"), " +
-                "env->CallStaticObjectMethod(gamecls, env->GetStaticMethodID(gamecls, \"get\", \"(J)L" + context.getPackageName() + "/Game;\"), (long)BroodwarPtr));\n" +
-                "\n" +
-                "\t\tjmethodID updateMethodID = env->GetMethodID(env->GetObjectClass(obj), \"update\", \"()V\");");
-
-        out.println("\t\tjmethodID matchStartCallback = env->GetMethodID(moduleCls, \"onStart\", \"()V\");\n" +
-                "\t\tjmethodID matchEndCallback = env->GetMethodID(moduleCls, \"onEnd\", \"(Z)V\");\n" +
-                "\t\tjmethodID matchFrameCallback = env->GetMethodID(moduleCls, \"onFrame\", \"()V\");\n" +
-                "\t\tjmethodID sendTextCallback = env->GetMethodID(moduleCls, \"onSendText\", \"(Ljava/lang/String;)V\");\n" +
-                "\t\tjmethodID receiveTextCallback = env->GetMethodID(moduleCls, \"onReceiveText\", \"(L" + context.getPackageName() + "/Player;Ljava/lang/String;)V\");\n" +
-                "\t\tjmethodID playerLeftCallback = env->GetMethodID(moduleCls, \"onPlayerLeft\", \"(L" + context.getPackageName() + "/Player;)V\");\n" +
-                "\t\tjmethodID nukeDetectCallback = env->GetMethodID(moduleCls, \"onNukeDetect\", \"(L" + context.getPackageName() + "/Position;)V\");\n" +
-                "\t\tjmethodID unitDiscoverCallback = env->GetMethodID(moduleCls, \"onUnitDiscover\", \"(L" + context.getPackageName() + "/Unit;)V\");\n" +
-                "\t\tjmethodID unitEvadeCallback = env->GetMethodID(moduleCls, \"onUnitEvade\", \"(L" + context.getPackageName() + "/Unit;)V\");\n" +
-                "\t\tjmethodID unitShowCallback = env->GetMethodID(moduleCls, \"onUnitShow\", \"(L" + context.getPackageName() + "/Unit;)V\");\n" +
-                "\t\tjmethodID unitHideCallback = env->GetMethodID(moduleCls, \"onUnitHide\", \"(L" + context.getPackageName() + "/Unit;)V\");\n" +
-                "\t\tjmethodID unitCreateCallback = env->GetMethodID(moduleCls, \"onUnitCreate\", \"(L" + context.getPackageName() + "/Unit;)V\");\n" +
-                "\t\tjmethodID unitDestroyCallback = env->GetMethodID(moduleCls, \"onUnitDestroy\", \"(L" + context.getPackageName() + "/Unit;)V\");\n" +
-                "\t\tjmethodID unitMorphCallback = env->GetMethodID(moduleCls, \"onUnitMorph\", \"(L" + context.getPackageName() + "/Unit;)V\");\n" +
-                "\t\tjmethodID unitRenegadeCallback = env->GetMethodID(moduleCls, \"onUnitRenegade\", \"(L" + context.getPackageName() + "/Unit;)V\");\n" +
-                "\t\tjmethodID saveGameCallback = env->GetMethodID(moduleCls, \"onSaveGame\", \"(Ljava/lang/String;)V\");\n" +
-                "\t\tjmethodID unitCompleteCallback = env->GetMethodID(moduleCls, \"onUnitComplete\", \"(L" + context.getPackageName() + "/Unit;)V\");\n" +
-                "\t\tjmethodID playerDroppedCallback = env->GetMethodID(moduleCls, \"onPlayerDropped\", \"(L" + context.getPackageName() + "/Player;)V\");");
-
-        out.println("\t\twhile (true) {\n");
-        implementConnectionRoutine();
-        out.println("\t\t\tprintln(\"Game ready!!!\");\n" +
-                "\n" +
-                "\t\t\twhile (Broodwar->isInGame()) {\n" +
-                "\t\t\t\t\n" +
-                "\t\t\t\tenv->CallVoidMethod(obj, updateMethodID);\n");
-        out.println("\n" +
-                "\t\t\t\tfor(std::list<Event>::const_iterator it = Broodwar->getEvents().begin(); it!=Broodwar->getEvents().end(); it++)\n" +
-                "\t\t\t\t  {\n" +
-                "\t\t\t\t\t  switch (it->getType()) {\n" +
-
-                "\t\t\t\t\t\t  case EventType::MatchStart:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, matchStartCallback);\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::MatchEnd:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, matchEndCallback, it->isWinner());\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::MatchFrame:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, matchFrameCallback);\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::SendText:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, sendTextCallback,  env->NewStringUTF(it->getText().c_str()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::ReceiveText:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, receiveTextCallback, env->CallStaticObjectMethod(playerCls, env->GetStaticMethodID(playerCls, \"get\", \"(J)L" + context.getPackageName() + "/Player;\"), (jlong)it->getPlayer()), env->NewStringUTF(it->getText().c_str()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::PlayerLeft:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, playerLeftCallback, env->CallStaticObjectMethod(playerCls, env->GetStaticMethodID(playerCls, \"get\", \"(J)L" + context.getPackageName() + "/Player;\"), (jlong)it->getPlayer()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::NukeDetect:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, nukeDetectCallback, env->NewObject(posCls, env->GetMethodID(posCls,\"<init>\", \"(II)V\"), it->getPosition().x, it->getPosition().y));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::UnitDiscover:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, unitDiscoverCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)L" + context.getPackageName() + "/Unit;\"), (jlong)it->getUnit()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::UnitEvade:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, unitEvadeCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)L" + context.getPackageName() + "/Unit;\"), (jlong)it->getUnit()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t   case EventType::UnitShow:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, unitShowCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)L" + context.getPackageName() + "/Unit;\"), (jlong)it->getUnit()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::UnitHide:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, unitHideCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)L" + context.getPackageName() + "/Unit;\"), (jlong)it->getUnit()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::UnitCreate:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, unitCreateCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)L" + context.getPackageName() + "/Unit;\"), (jlong)it->getUnit()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::UnitDestroy:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, unitDestroyCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)L" + context.getPackageName() + "/Unit;\"), (jlong)it->getUnit()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::UnitMorph:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, unitMorphCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)L" + context.getPackageName() + "/Unit;\"), (jlong)it->getUnit()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::UnitRenegade:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, unitRenegadeCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)L" + context.getPackageName() + "/Unit;\"), (jlong)it->getUnit()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::SaveGame:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, saveGameCallback, env->NewStringUTF(it->getText().c_str()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\t\t\t\t\t\t  case EventType::UnitComplete:\n" +
-                "\t\t\t\t\t\t\t  env->CallVoidMethod(moduleObj, unitCompleteCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)L" + context.getPackageName() + "/Unit;\"), (jlong)it->getUnit()));\n" +
-                "\t\t\t\t\t\t  break;\n" +
-                "\n" +
-                "\t\t\t\t\t  }\n" +
-                "\t\t\t\t  }");
-        out.println(
-                "\t\t\t\tBWAPIClient.update();\n" +
-                        "\t\t\t\tif (!BWAPI::BWAPIClient.isConnected()) {\n" +
-                        "\t\t\t\t\t\tprintln(\"Reconnecting...\");\n" +
-                        "\t\t\t\t\t\treconnect();\n" +
-                        "\t\t\t\t}\n" +
-                        "\t\t\t}\n" +
-                        "println(\"Match ended.\");" +
-                        "\t\t}");
-    }
-
     private void implementHelpers() {
-        out.println("void reconnect()\n" +
-                "{\n" +
-                "\twhile (!BWAPIClient.connect()) {\n" +
-                "            std::this_thread::sleep_for(std::chrono::milliseconds{ 1000 });\n" +
-                "    }\n" +
-                "}\n" +
-                "\n" +
-                "\n");
-
         out.println(
                 "void flushPrint(const char * text){\n" +
-                        "\tprintf(text);\n" +
-                        "\tfflush(stdout); \n" +
-                        "}\n" +
-                        "\n" +
-                        "void println(const char * text){\n" +
-                        "\tprintf(text);\n" +
-                        "\tflushPrint(\"\\n\");\n" +
-                        "}\n");
+                "   printf(text);\n" +
+                "   fflush(stdout); \n" +
+                "}\n" +
+                "\n" +
+                "void println(const char * text){\n" +
+                "   printf(text);\n" +
+                "   flushPrint(\"\\n\");\n" +
+                "}\n"
+        );
+        out.println();
 
     }
 
-    private void implementMirrorInit(List<CDeclaration> declarationList) {
-        implementHelpers();
-        out.println("JNIEXPORT void JNICALL Java_" + context.getPackageName() + "_Mirror_startGame(JNIEnv * env, jobject obj){");
+    private void implementMirror_initTables(List<CDeclaration> declarationList) {
+        out.println("JNIEXPORT void JNICALL Java_" + context.getPackageName() + "_Mirror_initTables(JNIEnv * env, jclass jclz){");
+        out.println("   println(\"Initializing constants tables\");");
         implementVariablesBind(declarationList);
-        implementGameStart();
         out.println("}");
+        out.println();
+    }
+
+    private void implementMirror_getInternalGame() {
+        out.println(
+                "JNIEXPORT jobject JNICALL Java_" + context.getPackageName() + "_Mirror_getInternalGame(JNIEnv * env, jobject obj){\n" +
+                "   jclass gamecls = env->FindClass(\"Lbwapi/Game;\");\n" +
+                "   jmethodID getMethodID = env->GetStaticMethodID(gamecls, \"get\", \"(J)Lbwapi/Game;\");\n" +
+                "   return env->CallStaticObjectMethod(gamecls, getMethodID, (long)BroodwarPtr);\n" +
+                "}\n"
+        );
+        out.println();
+    }
+
+    private void implementMirror_processGameEvents() {
+        out.println(
+                "JNIEXPORT void JNICALL Java_" + context.getPackageName() + "_Mirror_processGameEvents(JNIEnv * env, jobject obj){\n" +
+                "	jclass cls = env->GetObjectClass(obj);\n" +
+                "	jobject moduleObj = env->GetObjectField(obj, env->GetFieldID(cls, \"module\", \"Lbwapi/AIModule;\"));\n" +
+                "	jclass moduleCls = env->GetObjectClass(moduleObj);\n" +
+                "\n" +
+                "	jclass unitCls = env->FindClass(\"Lbwapi/Unit;\");\n" +
+                "	jclass playerCls = env->FindClass(\"Lbwapi/Player;\");\n" +
+                "	jclass posCls = env->FindClass(\"Lbwapi/Position;\");\n" +
+                "\n" +
+                "	jmethodID matchStartCallback = env->GetMethodID(moduleCls, \"onStart\", \"()V\");\n" +
+                "	jmethodID matchEndCallback = env->GetMethodID(moduleCls, \"onEnd\", \"(Z)V\");\n" +
+                "	jmethodID matchFrameCallback = env->GetMethodID(moduleCls, \"onFrame\", \"()V\");\n" +
+                "	jmethodID sendTextCallback = env->GetMethodID(moduleCls, \"onSendText\", \"(Ljava/lang/String;)V\");\n" +
+                "	jmethodID receiveTextCallback = env->GetMethodID(moduleCls, \"onReceiveText\", \"(Lbwapi/Player;Ljava/lang/String;)V\");\n" +
+                "	jmethodID playerLeftCallback = env->GetMethodID(moduleCls, \"onPlayerLeft\", \"(Lbwapi/Player;)V\");\n" +
+                "	jmethodID nukeDetectCallback = env->GetMethodID(moduleCls, \"onNukeDetect\", \"(Lbwapi/Position;)V\");\n" +
+                "	jmethodID unitDiscoverCallback = env->GetMethodID(moduleCls, \"onUnitDiscover\", \"(Lbwapi/Unit;)V\");\n" +
+                "	jmethodID unitEvadeCallback = env->GetMethodID(moduleCls, \"onUnitEvade\", \"(Lbwapi/Unit;)V\");\n" +
+                "	jmethodID unitShowCallback = env->GetMethodID(moduleCls, \"onUnitShow\", \"(Lbwapi/Unit;)V\");\n" +
+                "	jmethodID unitHideCallback = env->GetMethodID(moduleCls, \"onUnitHide\", \"(Lbwapi/Unit;)V\");\n" +
+                "	jmethodID unitCreateCallback = env->GetMethodID(moduleCls, \"onUnitCreate\", \"(Lbwapi/Unit;)V\");\n" +
+                "	jmethodID unitDestroyCallback = env->GetMethodID(moduleCls, \"onUnitDestroy\", \"(Lbwapi/Unit;)V\");\n" +
+                "	jmethodID unitMorphCallback = env->GetMethodID(moduleCls, \"onUnitMorph\", \"(Lbwapi/Unit;)V\");\n" +
+                "	jmethodID unitRenegadeCallback = env->GetMethodID(moduleCls, \"onUnitRenegade\", \"(Lbwapi/Unit;)V\");\n" +
+                "	jmethodID saveGameCallback = env->GetMethodID(moduleCls, \"onSaveGame\", \"(Ljava/lang/String;)V\");\n" +
+                "	jmethodID unitCompleteCallback = env->GetMethodID(moduleCls, \"onUnitComplete\", \"(Lbwapi/Unit;)V\");\n" +
+                "\n" +
+                "	for (std::list<Event>::const_iterator it = Broodwar->getEvents().begin(); it != Broodwar->getEvents().end(); it++)\n" +
+                "	{\n" +
+                "		switch (it->getType()) {\n" +
+                "		case EventType::MatchStart:\n" +
+                "			env->CallVoidMethod(moduleObj, matchStartCallback);\n" +
+                "			break;\n" +
+                "		case EventType::MatchEnd:\n" +
+                "			env->CallVoidMethod(moduleObj, matchEndCallback, it->isWinner());\n" +
+                "			break;\n" +
+                "		case EventType::MatchFrame:\n" +
+                "			env->CallVoidMethod(moduleObj, matchFrameCallback);\n" +
+                "			break;\n" +
+                "		case EventType::SendText:\n" +
+                "			env->CallVoidMethod(moduleObj, sendTextCallback, env->NewStringUTF(it->getText().c_str()));\n" +
+                "			break;\n" +
+                "		case EventType::ReceiveText:\n" +
+                "			env->CallVoidMethod(moduleObj, receiveTextCallback, env->CallStaticObjectMethod(playerCls, env->GetStaticMethodID(playerCls, \"get\", \"(J)Lbwapi/Player;\"), (jlong)it->getPlayer()), env->NewStringUTF(it->getText().c_str()));\n" +
+                "			break;\n" +
+                "		case EventType::PlayerLeft:\n" +
+                "			env->CallVoidMethod(moduleObj, playerLeftCallback, env->CallStaticObjectMethod(playerCls, env->GetStaticMethodID(playerCls, \"get\", \"(J)Lbwapi/Player;\"), (jlong)it->getPlayer()));\n" +
+                "			break;\n" +
+                "		case EventType::NukeDetect:\n" +
+                "			env->CallVoidMethod(moduleObj, nukeDetectCallback, env->NewObject(posCls, env->GetMethodID(posCls, \"<init>\", \"(II)V\"), it->getPosition().x, it->getPosition().y));\n" +
+                "			break;\n" +
+                "		case EventType::UnitDiscover:\n" +
+                "			env->CallVoidMethod(moduleObj, unitDiscoverCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)Lbwapi/Unit;\"), (jlong)it->getUnit()));\n" +
+                "			break;\n" +
+                "		case EventType::UnitEvade:\n" +
+                "			env->CallVoidMethod(moduleObj, unitEvadeCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)Lbwapi/Unit;\"), (jlong)it->getUnit()));\n" +
+                "			break;\n" +
+                "		case EventType::UnitShow:\n" +
+                "			env->CallVoidMethod(moduleObj, unitShowCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)Lbwapi/Unit;\"), (jlong)it->getUnit()));\n" +
+                "			break;\n" +
+                "		case EventType::UnitHide:\n" +
+                "			env->CallVoidMethod(moduleObj, unitHideCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)Lbwapi/Unit;\"), (jlong)it->getUnit()));\n" +
+                "			break;\n" +
+                "		case EventType::UnitCreate:\n" +
+                "			env->CallVoidMethod(moduleObj, unitCreateCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)Lbwapi/Unit;\"), (jlong)it->getUnit()));\n" +
+                "			break;\n" +
+                "		case EventType::UnitDestroy:\n" +
+                "			env->CallVoidMethod(moduleObj, unitDestroyCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)Lbwapi/Unit;\"), (jlong)it->getUnit()));\n" +
+                "			break;\n" +
+                "		case EventType::UnitMorph:\n" +
+                "			env->CallVoidMethod(moduleObj, unitMorphCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)Lbwapi/Unit;\"), (jlong)it->getUnit()));\n" +
+                "			break;\n" +
+                "		case EventType::UnitRenegade:\n" +
+                "			env->CallVoidMethod(moduleObj, unitRenegadeCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)Lbwapi/Unit;\"), (jlong)it->getUnit()));\n" +
+                "			break;\n" +
+                "		case EventType::SaveGame:\n" +
+                "			env->CallVoidMethod(moduleObj, saveGameCallback, env->NewStringUTF(it->getText().c_str()));\n" +
+                "			break;\n" +
+                "		case EventType::UnitComplete:\n" +
+                "			env->CallVoidMethod(moduleObj, unitCompleteCallback, env->CallStaticObjectMethod(unitCls, env->GetStaticMethodID(unitCls, \"get\", \"(J)Lbwapi/Unit;\"), (jlong)it->getUnit()));\n" +
+                "			break;\n" +
+                "		}\n" +
+                "	}\n" +
+                "}\n"
+        );
+        out.println();
+    }
+
+    private void implementMirror_BWAPIClientGetters() {
+        out.println(
+                "JNIEXPORT jboolean JNICALL Java_bwapi_Mirror_isConnected(JNIEnv * env, jclass jclz){\n" +
+                "	return BWAPI::BWAPIClient.isConnected();\n" +
+                "}\n" +
+                "\n" +
+                "JNIEXPORT jboolean JNICALL Java_bwapi_Mirror_connect(JNIEnv * env, jclass jclz){\n" +
+                "	return BWAPI::BWAPIClient.connect();\n" +
+                "}\n" +
+                "\n" +
+                "JNIEXPORT void JNICALL Java_bwapi_Mirror_disconnect(JNIEnv * env, jclass jclz){\n" +
+                "	BWAPI::BWAPIClient.disconnect();\n" +
+                "}\n" +
+                "\n" +
+                "JNIEXPORT void JNICALL Java_bwapi_Mirror_update(JNIEnv * env, jclass jclz){\n" +
+                "	BWAPI::BWAPIClient.update();\n" +
+                "}\n"
+        );
         out.println();
     }
 
@@ -251,7 +238,12 @@ public class Bind {
     }
 
     public void implementBind(List<CDeclaration> declarationList) {
-        implementMirrorInit(declarationList);
+        implementHelpers();
+        implementMirror_initTables(declarationList);
+        implementMirror_getInternalGame();
+        implementMirror_processGameEvents();
+        implementMirror_BWAPIClientGetters();
+
     }
 
 }


### PR DESCRIPTION
Converts the majority of functionality that was formerly in the JNI code for Mirror.startGame to Java code. Unfortunately I had to leave the BWAPI `Event` processing code as JNI code due to bugs with the generator projects ability to parse and emit mirrors for C++ `enum` types and methods using those enum types (it's seriously pretty broken actually).

In addition, `startGame` now takes a boolean parameter which controls if the main `while` loop runs indefinitely or not. Running indefinitely is the old behaviour where `startGame` blocks and you are forced to call something like `System.exit` to quit. 

Passing `false` will make it so `startGame` returns after the match ends (regardless of what the reason for it ending was). Before returning, the BWAPI connection to Broodwar is disconnected. `startGame` can be called any number of times to run multiple matches in a row, but the important thing is that this makes it _far_ easier to exactly control this type of thing from the calling code. Hooray!